### PR TITLE
Update expectToThrow

### DIFF
--- a/src/helpers/expectToThrow.ts
+++ b/src/helpers/expectToThrow.ts
@@ -10,7 +10,7 @@ export const expectToThrow = async (promise: Promise<any>, errorMsg?: string) =>
         await promise
         throw new Error(`Was expecting to fail with ${errorMsg}`)
     } catch (e: any) {
-        if ( errorMsg ) expect(e.message).to.include(errorMsg)
+        if ( errorMsg ) expect(e.message).to.be.deep.eq(errorMsg)
         else expect(!!e.message).to.be.true;
     }
 }


### PR DESCRIPTION
- [ ] allow optional `errorMsg` to not require an error message

### Example

```ts
const action = contract.actions.regprotocol(["myprotocol"]).send('foobar@active');
//=> throws error: missing required authority myprotocol

await expectToThrow(action, "missing required authority myprotocol"); // pass
await expectToThrow(action); // pass
```