### PR TITLE
allow .send() without @active authorization

### DIFF
--- a/src/proton/account.ts
+++ b/src/proton/account.ts
@@ -12,7 +12,7 @@ export type AccountArgs = Omit<Partial<Account>, 'name'|'abi'|'wasm'> & {
   enableInline?: boolean;
 }
 
-function isPromise(promise: any) {  
+function isPromise(promise: any) {
   return !!promise && typeof promise.then === 'function'
 }
 
@@ -82,7 +82,7 @@ export class Account {
   buildActions () {
     this.abi.actions.forEach((action) => {
       const resolved = this.abi.resolveType(action.name.toString());
-      
+
       this.actions[resolved.name] = (actionData: any[] | object) => {
         const data: Record<string, any> = {};
 
@@ -93,7 +93,7 @@ export class Account {
             if (!field.type.isOptional && !actionData.hasOwnProperty(field.name)) {
               throw new Error(`Missing field ${field.name} on action ${action.name}`);
             }
-  
+
             if (actionData.hasOwnProperty(field.name)) {
               data[field.name] = actionData[field.name]
             }
@@ -108,11 +108,13 @@ export class Account {
 
         return {
           send: async (authorization?: string | PermissionLevelType | PermissionLevelType[], options?: Partial<TransactionHeader>) => {
+            // .send()
             if (!authorization) {
-              authorization = {
-                actor: this.name,
-                permission: 'active'
-              }
+              authorization = `${this.name}@active`;
+            }
+            // .send("account")
+            else if ( typeof authorization == "string" && !authorization.includes("@") ) {
+              authorization += '@active';
             }
 
             await this.bc.applyTransaction(Transaction.from({

--- a/src/proton/tests/blockchain.spec.ts
+++ b/src/proton/tests/blockchain.spec.ts
@@ -69,7 +69,7 @@ describe('eos-vm', () => {
 
     it('create: symbol_already_exists', async () => {
       const action = eosioToken.actions.create(['alice', '100 TKN'])
-      
+
       await action.send();
 
       try {
@@ -110,8 +110,8 @@ describe('eos-vm', () => {
       const symcode = 'TKN';
 
       await eosioToken.actions.create(['alice', `1000.000 ${symcode}`]).send();
-      await eosioToken.actions.issue(['alice', `500.000 ${symcode}`, 'hola']).send('alice@active');
-      
+      await eosioToken.actions.issue(['alice', `500.000 ${symcode}`, 'hola']).send('alice');  // without @active authorization
+
       expect(getStat(symcode)).to.be.deep.equal(currency_stats('500.000 TKN', '1000.000 TKN', 'alice'))
       expect(getAccount('alice', symcode)).to.be.deep.equal(account('500.000 TKN'))
 


### PR DESCRIPTION
Allows both authorization to be valid:

```ts
await eosioToken.actions.issue(['alice', '500.001 TKN', 'hola']).send('alice');
await eosioToken.actions.issue(['alice', '500.001 TKN', 'hola']).send('alice@active');
```

Fixes https://github.com/ProtonProtocol/vert/issues/2